### PR TITLE
MongoDB Reader handles multiple CollectionFilters

### DIFF
--- a/adaptor/mongodb/mongodb.go
+++ b/adaptor/mongodb/mongodb.go
@@ -68,7 +68,7 @@ func (m *mongoDB) Client() (client.Client, error) {
 }
 
 func (m *mongoDB) Reader() (client.Reader, error) {
-	var f map[string]CollectionFilter
+	var f map[string][]CollectionFilter
 	if m.CollectionFilters != "" {
 		if jerr := json.Unmarshal([]byte(m.CollectionFilters), &f); jerr != nil {
 			return nil, ErrCollectionFilter


### PR DESCRIPTION
Before this PR it is possible to specify a CollectionFilter for a MongoDB source as shown below:

```
var source = mongodb({
  "uri": "mongodb://localhost:32769/local_database",
  "collection_filters": "{ \"collectionname\": {\"property\": \"test.68817\"}}",
})
```

The source specifies that only documents from the ```collectionname``` collection with a ```property``` of ```test.68817``` are transported.

There is no existing way to specify multiple values for ```property```.

This PR changes the collection filter in the mongodb source config to be an array of strings rather than just a string. This allows documents with multiple values of ```property``` to be filtered and transported at the same time:

```
var source = mongodb({
  "uri": "mongodb://localhost:32769/local_database",
  "collection_filters": "{ \"collectionname\": [{\"property\": \"test.68817\"}, {\"property\":\"test.88217\"}]}",
})

```  


### Required for all PRs:

- [ ] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)
- [ ] README.md updated (if needed)
